### PR TITLE
Upgrade xmlhttprequest-ssl to version 1.6.2 or later

### DIFF
--- a/webrtc-test/package-lock.json
+++ b/webrtc-test/package-lock.json
@@ -640,7 +640,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       }
     },


### PR DESCRIPTION
Upgrade xmlhttprequest-ssl to version 1.6.2 or later as recommended by GitHub Dependabot